### PR TITLE
Install ripe-atlas-tools latest tag instead of master

### DIFF
--- a/roles/ripe-atlas/tasks/main.yml
+++ b/roles/ripe-atlas/tasks/main.yml
@@ -12,5 +12,5 @@
 
 - name: "Install ripe-atlas-tools from git"
   pip:
-    name='git+https://github.com/RIPE-NCC/ripe-atlas-tools#egg=ripe-atlas-tools'
+    name='git+https://github.com/RIPE-NCC/ripe-atlas-tools@latest#egg=ripe-atlas-tools'
 


### PR DESCRIPTION
It's safer if the installation comes from tag called "latest", which points to the commit that our latest PYPI release came from. master doesn't guarantee that will be always stable :)
Alternatively you can download it from PYPI directly instead of github...