### PR TITLE
make_nginx_dual_stack_again

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -8,7 +8,7 @@ events {
 
 http {
     server {
-        listen [::]:80;
+        listen [::]:80 ipv6only=off;
         access_log /var/log/nginx/access.log;
         error_log /var/log/nginx/error.log;
         return 301 https://ring.nlnog.net/;


### PR DESCRIPTION
New nginx behaviour change prevents IPv4 binding , meaning listeners are now v6 only, breaking existing v4 monitoring for folk (https://codinginthetrenches.com/2013/12/14/nginx-ipv6only-setting-gotcha/) 