### PR TITLE
Install ed25519 gem to make ring-all work with ed25519 keys

### DIFF
--- a/roles/userscripts/tasks/main.yml
+++ b/roles/userscripts/tasks/main.yml
@@ -35,6 +35,7 @@
     - net-ssh
     - rbnacl-libsodium
     - bcrypt_pbkdf
+    - ed25519
 
 - name: "Install ring userscripts"
   copy:


### PR DESCRIPTION
If user has ed25519 ssh keys currently the ring-all does not work as the ed25519 gem is missing from the nodes.

