### PR TITLE
Install Paris Traceroute

### DIFF
--- a/roles/software/tasks/main.yml
+++ b/roles/software/tasks/main.yml
@@ -57,6 +57,7 @@
     - netsed
     - ngrep
     - nmap
+    - paris-traceroute
     - pastebinit
     - psmisc
     - pv
@@ -166,6 +167,7 @@
     - /usr/sbin/hping3
     - /usr/bin/nmap
     - /usr/bin/nping
+    - /usr/sbin/paris-traceroute
     - /usr/bin/traceroute.db
     - /usr/sbin/tcpdump
     - /usr/bin/dumpcap


### PR DESCRIPTION
Paris Traceroute is an ECMP-aware traceroute implementation. It can discover
and report on all unique ECMP / load balanced paths betweeen itself and the
destination, which can be very useful for debugging purposes.

Homepage: https://paris-traceroute.net