### PR TITLE
Fix segfault in ring-curl

### DIFF
--- a/roles/userscripts/files/ring-curl
+++ b/roles/userscripts/files/ring-curl
@@ -188,6 +188,9 @@ sub parse_info {
         # The following items cause segfaults
         next if ($entry =~ /^CURLINFO_CERTINFO/);
         next if ($entry =~ /^CURLINFO_SLIST/);
+        next if ($entry =~ /^CURLINFO_TLS_SESSION/);
+        next if ($entry =~ /^CURLINFO_TLS_SSL_PTR/);
+        next if ($entry =~ /^CURLINFO_STRING/);
 
         my $name = lc($entry);
         $name =~ s/^curlinfo_//;


### PR DESCRIPTION
Currently, ring-curl segfaults whenever trying to run any curl command (easy reproducible using ring --local https://nlnog.net/)

After a bit of debugging and excluding all keys in `parse_info` and enabling them one by one, I found that 3 keys: `CURLINFO_TLS_SESSION`, `CURLINFO_TLS_SSL_PTR`, `CURLINFO_STRING` all cause the script to segfault.