### PR TITLE
Ansible 2.3 compatibility for kafka role, run_local.sh helper

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -82,11 +82,11 @@
   roles:
     - { role: munin-master, tags: munin-master }
 
-#- hosts: compute02.infra.ring.nlnog.net
-#  become: true
-#  become_user: root
-#  roles:
-#    - { role: kafka, tags: kafka }
+- hosts: compute02.infra.ring.nlnog.net
+  become: true
+  become_user: root
+  roles:
+    - { role: kafka, tags: kafka }
 
 - hosts: lg01.infra.ring.nlnog.net
   become: true

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -1,16 +1,15 @@
 ---
 # local service user
-- import_tasks: user.yml
+- include: user.yml
   when: kafka_configure_broker or kafka_configure_zookeeper
 
 # download + unpack kafka
-- import_tasks: install.yml
+- include: install.yml
   when: kafka_configure_broker or kafka_configure_zookeeper
 
 # Kafka configs
-- import_tasks: kafka.yml
+- include: kafka.yml
   when: kafka_configure_broker
 
-- import_tasks: zookeeper.yml
+- include: zookeeper.yml
   when: kafka_configure_zookeeper
-

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Run ring-ansible from a local checkout (for development)
+
+export ANSIBLE_FORCE_COLOR=1
+
+/usr/bin/ansible-pull --full -d $(pwd) \
+    -U https://github.com/NLNOG/ring-ansible.git \
+    --vault-password-file=/root/.vaultpw \
+    -i nodes \
+    -l $(hostname) \
+    -c local \
+    -f $@ playbook.yml


### PR DESCRIPTION
Tested on marbis01.

Unfortunately, this fix will be short-lived if 18.04 upgrades to 2.8:

    [DEPRECATION WARNING]: 'include' for playbook includes. You should use
    'import_playbook' instead. This feature will be removed in version 2.8. Deprecation
    warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

This would be surprising for a LTS release, but who knows...

 