### PR TITLE
etcfiles/hosts.j2: fix ordering of fqdn/alias in /etc/hosts

### DIFF
--- a/roles/etcfiles/templates/hosts.j2
+++ b/roles/etcfiles/templates/hosts.j2
@@ -14,10 +14,10 @@ ff02::2 ip6-allrouters
 {% for host in groups['all']|sort %}
 {% set short_id = host|regex_replace("\.ring\.nlnog\.net", "") %}
 {% if hostvars[host]['V6']|default(None) %}
-{{ hostvars[host]['V6'] }}    {{ short_id }} {{ host }}
+{{ hostvars[host]['V6'] }}    {{ host }} {{ short_id }}
 {% endif %}
 {% if hostvars[host]['V4']|default(None) %}
-{{ hostvars[host]['V4'] }}    {{ short_id }} {{ host }}
+{{ hostvars[host]['V4'] }}    {{ host }} {{ short_id }}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
The correct syntax for entries in `/etc/hosts` is, according to *hosts(5)*,
as follows:

```
              IP_address canonical_hostname [aliases...]
```

The ordering of `canonical_hostname` and `alias` is currently the wrong way
around, causing incorrect output from `hostname --fqdn`:

```
redpilllinpro@redpilllinpro02:~$ fgrep $(hostname) /etc/hosts
2a02:c0:400:108::1    redpilllinpro02 redpilllinpro02.ring.nlnog.net
87.238.39.42    redpilllinpro02 redpilllinpro02.ring.nlnog.net
redpilllinpro@redpilllinpro02:~$ hostname --fqdn
redpilllinpro02
```