### PR TITLE
Fix admininfo

### DIFF
--- a/roles/motd/files/60-node-information
+++ b/roles/motd/files/60-node-information
@@ -18,7 +18,7 @@ def get_api_object(url):
         return None
 
 def get_admininfo(pid):
-    node=socket.gethostbyaddr(HOSTNAME)[0]
+    node=socket.gethostbyaddr(HOSTNAME)[1][0]
     org = re.sub('..$','',node)
     return os.popen("getent passwd "+org+" | cut -d : -f 5").read().strip()
 


### PR DESCRIPTION
The first item in the return value of socket.gethostbyaddr is the FQDN, so the script isn't able to find the correct user for the node. This PR fixes this issue.

```>>> socket.gethostbyaddr(HOSTNAME)
('breedbandnl01.ring.nlnog.net', ['breedbandnl01'], ['2a03:4f00:20:0:250:56ff:fe01:57'])```