### PR TITLE
Add Neptune Networks as looking glass peer

### DIFF
--- a/roles/bird/vars/peers.yml
+++ b/roles/bird/vars/peers.yml
@@ -228,6 +228,10 @@ lg_peers:
     asn: 2848
     ipv4: 93.180.0.143
     ipv6: 2a00:f480::14
+  NEPTUNE1:
+    asn: 397143
+    ipv4: 23.157.160.1
+    ipv6: 2602:fe2e::1
   NETSIGN1:
     asn: 31078
     ipv4: 217.115.0.27


### PR DESCRIPTION
This commit adds AS397143 (Neptune Networks) as a BGP peer to participate in the RING looking glass. The other end of this BGP session is up and running and should Just Work™.