### PR TITLE
Add global ring-users account for leopold

### DIFF
--- a/host_vars/compute02.infra.ring.nlnog.net
+++ b/host_vars/compute02.infra.ring.nlnog.net
@@ -23,17 +23,6 @@ LOCAL_USERS:
       - admin
     sshkeys:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDSE9b7iPp22wQbIeiB6YUQAkJQk2wpXiBn1DZbbs80geEvihud3m2hlYwGLuFVyME83fX7Md8997RRsR6PWqxEyWa5TI+A9oxCNBZv30sVOdg4wn3qTux5V4d30GaV5/+10tocb4JSjDpZPT3vbDJjxcyWON+EQXOYa06bAbLFJV/L9jKodlq483ANOlbzcQ3U2DDdENZEWj2kgbGNR41O356FW/u4eU3n1G6n/R0vz+nHL/CZXcMwPR8RwhTUFOJXY143n56ivXgN0cJvzvlhAQHPu7iQk9WqjbKGvjo8Kx+wWJNM4t36lwu7as9J5AZYfeaBYOmqLe5ZDy0lu6JelAVVo7jD36S4siQEjE1AAM+/OOk69NH5Yu0fjoA+OA0vysM9lD4UWghYQs5Hced9VrC7FNz52GbM8hI4F60q+xMX8d1Qm4hN2D11mwdM89ZemA3glrKtohzIDh53zP0QzzpoXesuKFnTuwX5QwV5OqaOD7i7YhjUDlObHtrGQPpgdaWhYRyqL+vyLXGy3zYE0Tyj5HGMksyWz5wGjThYOXAMRtDZNlYKTRk/LaT+ToXP1ZS0fW2mOS33gaLv+OZHgVzi3mUJD5jC7y9tUffRdH/Rum4Y5wChjsZFPPmzDaQsuSENuHl1/vqxk2CsI11Ck8uimnPYsLyXASNThLzfdQ== jeroen@jeroen.sidn.nl"
-  leopold:
-    state: present
-    company: 'NLNOG Ring Admins'
-    email: mail@leoschabel.de
-    uid: 62004
-    shell: /bin/bash
-    groups:
-      - ring-users
-      - admin
-    sshkeys:
-      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUUJrDp3xdU9mumOMFQiDxL5rNRo7nVTrkVNPdx077u3mOX6Xy0vlr4BL2MA0cR5lRe2HNp1JBlPoinrFJDAK9uLSupZ+lycgcEPbtaz7FV/HAKtSJ5sOC95kA935GvV9/XsbdHcWhNilkPMe0bRUDoTGMFNc1YAaJfYnD2jAoJtfPR7Yswktp0TfBuTDSl7m6Bj50VPjRSd6Tj+WURI+X94hWnNd4Q9Iv7vQZ3bq7pFZAogK0hb+FBT9NaU57NnerCNpFCmgIVSwYevdeh610imA7d00bzjoY57NhqqRGDKLdg8y3JKvjFrVTn2gdoYyRy/CzyRFipHWwU0b6vlOV leopold'
 
 apache_vhosts:
   - graphite

--- a/nodes
+++ b/nodes
@@ -534,7 +534,7 @@ public02.infra.ring.nlnog.net OWNER=job V4=95.211.149.18 V6=2001:1AF8:4013::18
 backup.infra.ring.nlnog.net OWNER=job V4=109.72.93.35 V6=2a00:f10:122::35
 auth.infra.ring.nlnog.net OWNER=job V4=95.211.149.22 V6=2001:1AF8:4013::22
 compute01.infra.ring.nlnog.net OWNER=job V4=52.17.9.249 V6=2a05:d018:9f2:ed01::2:1
-compute02.infra.ring.nlnog.net OWNER=job V4=54.173.241.225 V6=2600:1f18:415a:7301::102
+compute02.infra.ring.nlnog.net OWNER=leopold V4=54.173.241.225 V6=2600:1f18:415a:7301::102
 storage01.infra.ring.nlnog.net OWNER=job V4=52.18.186.201 V6=2a05:d018:9f2:ed01::3:1
 public03.infra.ring.nlnog.net OWNER=job V4=185.107.224.27 V6=2a00:f10:400:2:4b3:4aff:fe00:707
 container07.infra.ring.nlnog.net OWNER=job V4=82.94.249.164 V6=2001:888:2000:3e::1339

--- a/roles/users/vars/ring-admins.yml
+++ b/roles/users/vars/ring-admins.yml
@@ -98,3 +98,14 @@ USERS:
     sshkeys:
       - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN6hHF8fy+vZ2wcxndGsX48wVWiKuYP2S17B6dloZywe sunfield@caprica.local'
       - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCsRhs9iY8ZxEYrTRjg5BbK7rbzHMlqbK/v5qwPjEQ6/zqBkzoqQgdO1ydveEVGJj/nZbTZWQ6uNnSRKCjMl1L+tVXtVsbnVpvNtccpC/kdPu1v8Qj+5fvfHBEIPPpA4RNZeSS/jbe5IgbMcVDh7R8FrSgxTifJijpYq0VRb/3EsKQgvVvg+7PgN3y8mzK8WgckTy5i1nU0R6J6pIftIllj/vZzn5e9vibVWmmcTR8C76Eefu99aGOK8Kw/3bEjPaDug5MHREOb2zUFSBj2OJF73LQktUP0fgnlMIYN9fIADcVzJ8fCwFLyk3Lq3MM3o6Kgfl9dyWziItJ0/1PlMYN1l6+qF8VQLXQpT+4+BS8QnKVDFJJWE3Woims1HFoCTL6bFOkH/iUHG5egPkxBTjpvu19a4xxALp0d+WkvKWcEkK9ZrAVSr3CIPDhtyL0a0/mgX24b/X8TL5o09nHHSWggtLaWkt4wRmRapPuif3dHXh+G8lRdhSucehYCrKJA4AStNE7PwqNMtSPpc3m6l9Twe0XUzbMVoliF98fnLiIkWqf1uvj1TJluGxW980r3Ya5B/ocJmhiDONNenBOVtosb1Xis/nadPWc0Udxk/f/FZ9+rdwXCo5OFUsMheE1bGStU5GHXymvsk4WLxb/iytQymCPcBv/QQu54z4PKhpdcYw== sunfield@caprica.local'
+
+  leopold:
+    state: present
+    company: "Leopold Schabel"
+    email: ring@leoluk.de
+    uid: 6009
+    shell: /bin/bash
+    groups:
+      - ring-users
+    sshkeys:
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUUJrDp3xdU9mumOMFQiDxL5rNRo7nVTrkVNPdx077u3mOX6Xy0vlr4BL2MA0cR5lRe2HNp1JBlPoinrFJDAK9uLSupZ+lycgcEPbtaz7FV/HAKtSJ5sOC95kA935GvV9/XsbdHcWhNilkPMe0bRUDoTGMFNc1YAaJfYnD2jAoJtfPR7Yswktp0TfBuTDSl7m6Bj50VPjRSd6Tj+WURI+X94hWnNd4Q9Iv7vQZ3bq7pFZAogK0hb+FBT9NaU57NnerCNpFCmgIVSwYevdeh610imA7d00bzjoY57NhqqRGDKLdg8y3JKvjFrVTn2gdoYyRy/CzyRFipHWwU0b6vlOV leopold'


### PR DESCRIPTION
Tested on compute02.infra.ring.nlnog.net after manually removing
the existing local account. Changing the OWNER tag takes care of
adding the account to the local admin group.
