### PR TITLE
Override long TTLs

### DIFF
--- a/roles/resolving/templates/unbound.conf.j2
+++ b/roles/resolving/templates/unbound.conf.j2
@@ -12,3 +12,5 @@ server:
     access-control: 127.0.0.0/8 allow_snoop
     access-control: ::1 allow_snoop
     access-control: ::ffff:127.0.0.1 allow_snoop
+    # Override TTL when it is too long, to allow for faster re-testing
+    cache-max-ttl: 3600


### PR DESCRIPTION
Override TTL of the local resolver when it longer than 3600 seconds, to allow for faster re-testing, instead of having to wait, like for example an entire day when the tested FQDN has a TTL of 86400 seconds.