### PR TITLE
Set compatibility_level = 2 for Postfix

### DIFF
--- a/roles/postfix/templates/main.cf
+++ b/roles/postfix/templates/main.cf
@@ -6,3 +6,6 @@ smtp_reply_filter = pcre:/etc/postfix/smtp_reply_filter
 {% if postfix_home_mailbox | d() %}
 home_mailbox = {{ postfix_home_mailbox }}
 {% endif %}
+{% if ansible_distribution_release == "bionic" %}
+compatibility_level = 2
+{% endif %}


### PR DESCRIPTION
From Postfix documentation: "IMPORTANT: Either the smtpd_relay_restrictions or the smtpd_recipient_restrictions parameter must specify at least one of the following restrictions. Otherwise Postfix will refuse to receive mail."

Neither is set currently and thus Postfix will fail to start:
postfix/smtpd[448]: fatal: in parameter smtpd_relay_restrictions or smtpd_recipient_restrictions, specify at least one working instance of: reject_unauth_destination, defer_unauth_destination, reject, defer, defer_if_permit or check_relay_domains
postfix/master[1927]: warning: process /usr/lib/postfix/sbin/smtpd pid 448 exit status 1
postfix/master[1927]: warning: /usr/lib/postfix/sbin/smtpd: bad command startup -- throttling

Compatibility mode needs to be set value of 2 per release notes after configuration review has been done -> no issues found why Postfix should run in compatibility mode.

This will lead smtpd_relay_restrictions to be set (postconf -d)
smtpd_relay_restrictions = ${{$compatibility_level} < {1} ? {} : {permit_mynetworks, permit_sasl_authenticated, defer_unauth_destination}}
