### PR TITLE
ubuntu_upgrade.yml: Removed manually add of sources.list entries for bionic

### DIFF
--- a/ubuntu_upgrade.yml
+++ b/ubuntu_upgrade.yml
@@ -146,35 +146,6 @@
         - /etc/apt/apt.conf.d/50unattended-upgrades
         - /etc/apt/apt.conf.d/50unattended-upgrades.dpkg-dist
 
-    - name: "Add ubuntu bionic repository"
-      apt_repository:
-        repo: 'deb http://ftp.bit.nl/ubuntu bionic main restricted universe multiverse'
-        state: present
-        filename: 'bit_ubuntu_archiv_bionic'
-
-    - name: "Add ubuntu bionic updates repository"
-      apt_repository:
-        repo: 'deb http://ftp.bit.nl/ubuntu bionic-updates main restricted universe multiverse'
-        state: present
-        filename: 'bit_ubuntu_archiv_bionic-updates'
-
-    - name: "Add ubuntu bionic security repository"
-      apt_repository:
-        repo: 'deb http://ftp.bit.nl/ubuntu bionic-security main restricted universe multiverse'
-        state: present
-        filename: 'bit_ubuntu_archiv_bionic-security'
-
-    - name: "Remove ubuntu xenial repositories"
-      file: name={{ item }} state=absent
-      with_items:
-        - '/etc/apt/sources.list.d/ubuntu_archiv_xenial.list'
-        - '/etc/apt/sources.list.d/ubuntu_archiv_xenial-updates.list'
-        - '/etc/apt/sources.list.d/ubuntu_archiv_xenial-security.list'
-
-    - name: "apt-get update (bionic repos)"
-      apt:
-        update_cache: yes
-
     - name: "Perform release upgrade (xenial -> bionic)"
       command: do-release-upgrade -f DistUpgradeViewNonInteractive
       when: ansible_distribution_release != "bionic"


### PR DESCRIPTION
When I ran sudo /usr/local/sbin/ansible-distupgrade to upgrade I've got:
<code>
TASK [Perform release upgrade (xenial -> bionic)] **************************************************************************************
fatal: [plutex01.ring.nlnog.net]: FAILED! => {"changed": true, "cmd": ["do-release-upgrade", "-f", "DistUpgradeViewNonInteractive"], "delta": "0:00:03.893722", "end": "2020-08-12 10:25:16.466686", "failed": true, "rc": 1, "start": "2020-08-12 10:25:12.572964", "stderr": "", "stderr_lines": [], "stdout": "Checking for a new Ubuntu release\nPlease install all available updates for your release before upgrading.", "stdout_lines": ["Checking for a new Ubuntu release", "Please install all available updates for your release before upgrading."], "warnings": []}
	to retry, use: --limit @/etc/ansible/ring/ubuntu_upgrade.retry
</code>

I think its because ansible adds sources for bionic and run apt update. At this point apt thinks "oh. there are update" and do-release-upgrade breaks. Also do-release-upgrade should be fixing the sources.list by itself.   