### PR TITLE
Swap BGP.Tools collecter from Private ASN to new Public ASN

### DIFF
--- a/roles/bird/vars/peers.yml
+++ b/roles/bird/vars/peers.yml
@@ -468,6 +468,6 @@ readonly_peers:
     ipv4: 185.199.217.227
     ipv6: 2a0a:a3c0:0:d2ca::217:227
   BGPDOTTOOLS:
-    asn: 4294967290
+    asn: 212232
     ipv4: 185.230.223.92
     ipv6: 2a0c:2f07:9459:592::2


### PR DESCRIPTION
bgp.tools'es route collector now has a public ASN for
collecting, so let's swap NLNOG over to it