### PR TITLE
Install ed25519 & bcrypt-pbkdf gems to fix ring-all dependencies

### DIFF
--- a/roles/userscripts/tasks/main.yml
+++ b/roles/userscripts/tasks/main.yml
@@ -22,6 +22,13 @@
   gem: name=net-ssh executable=/usr/bin/gem user_install=no
   when: ansible_distribution_release == "jammy"
 
+- name: "Install ring-all net-ssh dependencies"
+  apt: name={{ item }} state=latest
+  with_items:
+    - ruby-ed25519
+    - ruby-bcrypt-pbkdf
+  when: ansible_distribution_release == "jammy"
+
 - name: "install ruby-rbnacl"
   apt: name=ruby-rbnacl state=latest
   when: ansible_distribution_release == "jammy"


### PR DESCRIPTION
ring-all/net-ssh requires ed25519 and bcrypt-pbkdf gems to support ed25519, without these ring-all does not connect any nodes currently.