### PR TITLE
move from ftp.bit.nl to nl.archive.ubuntu.com

### DIFF
--- a/roles/apt/tasks/main.yml
+++ b/roles/apt/tasks/main.yml
@@ -47,19 +47,19 @@
 
 - name: "Add ubuntu {{ ansible_distribution_release }} repository"
   apt_repository:
-    repo: 'deb http://ftp.bit.nl/ubuntu {{ ansible_distribution_release }} main restricted universe multiverse'
+    repo: 'deb http://nl.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} main restricted universe multiverse'
     state: present
     filename: 'bit_ubuntu_archiv_{{ ansible_distribution_release }}'
 
 - name: "Add ubuntu {{ ansible_distribution_release }} updates repository"
   apt_repository:
-    repo: 'deb http://ftp.bit.nl/ubuntu {{ ansible_distribution_release }}-updates main restricted universe multiverse'
+    repo: 'deb http://nl.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-updates main restricted universe multiverse'
     state: present
     filename: 'bit_ubuntu_archiv_{{ ansible_distribution_release }}-updates'
 
 - name: "Add ubuntu {{ ansible_distribution_release }} security repository"
   apt_repository:
-    repo: 'deb http://ftp.bit.nl/ubuntu {{ ansible_distribution_release }}-security main restricted universe multiverse'
+    repo: 'deb http://nl.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main restricted universe multiverse'
     state: present
     filename: 'bit_ubuntu_archiv_{{ ansible_distribution_release }}-security'
 

--- a/roles/ring_health/files/ring-health
+++ b/roles/ring_health/files/ring-health
@@ -73,8 +73,8 @@ def main(argv):
         # HTTP/HTTPS checks
         health['https_github'] = check_weburl('https://github.com/')
         descriptions['https_github'] = "A webrequest for 'https://github.com/' succeeded"
-        health['http_aptrepo_bit'] = check_weburl('http://ftp.bit.nl/ubuntu')
-        descriptions['http_aptrepo_bit'] = "A webrequest for 'http://ftp.bit.nl/ubuntu' succeeded"
+        health['http_aptrepo_bit'] = check_weburl('http://nl.archive.ubuntu.com/ubuntu')
+        descriptions['http_aptrepo_bit'] = "A webrequest for 'http://nl.archive.ubuntu.com/ubuntu' succeeded"
         health['http_aptrepo_ring'] = check_weburl('http://apt.ring.nlnog.net/deb/dists/ring/Release')
         descriptions['http_aptrepo_ring'] = "A webrequest for 'http://apt.ring.nlnog.net/deb/dists/ring/Release' succeeded"
 


### PR DESCRIPTION
move from ftp.bit.nl to nl.archive.ubuntu.com, so in case BIT offloads their repo to another server we still have working repositories.