### PR TITLE
Add AS199471 S5B to looking glass

### DIFF
--- a/roles/openbgpd/vars/peers.yml
+++ b/roles/openbgpd/vars/peers.yml
@@ -670,6 +670,12 @@ lg_peers:
   AS203686_ILHAM_JKT_ATH:
     asn: 203686
     ipv6: 2a06:9f44:f170::6
+  AS199471_S5B_DUS:
+    asn: 199471
+    ipv6: 2a13:fc80:fffe::1
+  AS199471_S5B_FRA:
+    asn: 199471
+    ipv6: 2a13:fc80:fffd::1
 
 
 readonly_peers:


### PR DESCRIPTION
Added AS199471 with two location Dusseldorf and Frankfurt.
Both nodes have access to different IXPs and hance different visibilities into the DFZ.