### PR TITLE
Add readonly peer

### DIFF
--- a/roles/openbgpd/vars/peers.yml
+++ b/roles/openbgpd/vars/peers.yml
@@ -782,3 +782,7 @@ readonly_peers:
     asn: 57984
     ipv4: 91.207.120.39
     ipv6: 2a0b:2f07:abcd:234::39
+  BASED_RC0THTP:
+    asn: 21991
+    ipv4: 198.8.59.40
+    ipv6: '2a0f:85c1:31:2c::'


### PR DESCRIPTION
Hi, I am trying to build a nice REST API to query the NLNOG LG instead of having to parse `/prefix/text`. The code and the interface will be open source and will be free of all to use (with reasonable ratelimits).

I also plan on adding integration with https://github.com/PEERINGTestbed/peeringmon_exporter/