### PR TITLE
Update QUXLABS1v6 Peer Address

### DIFF
--- a/roles/openbgpd/vars/peers.yml
+++ b/roles/openbgpd/vars/peers.yml
@@ -607,7 +607,7 @@ lg_peers:
   QUXLABS1:
     asn: 203038
     ipv4: 185.243.23.254
-    ipv6: '2a0a:3507:1::'
+    ipv6: 2a0d:bbc0:1::1
   RADISHNETWORKS1:
     asn: 399580
     ipv4: 209.209.88.249


### PR DESCRIPTION
IPv6 was moved to a different prefix a while back; just catching up on all the spots where I need to change this.