### PR TITLE
enable handling of v4v6 NH gateways

### DIFF
--- a/roles/ring_health/files/ring-health
+++ b/roles/ring_health/files/ring-health
@@ -299,7 +299,14 @@ def check_ipv4_gw():
         # Unnumbered gateway
         if route_vars[1] == 'dev':
             return True
-        gw = route_vars[2]
+        # Explicit IPv6 next-hop
+        if ':' in line:
+            gw = route_vars[3]
+            # Check for ll gw (needs Interface spec)
+            if gw.startswith('fe'):
+                gw = "{gw}%{intf}".format(gw=gw, intf=route_vars[-1])
+        else:
+            gw = route_vars[2]
         ping_result = subprocess.run(['ping', '-c', '3', gw],
                                      stdout=subprocess.PIPE)
         if ping_result.returncode == 0:


### PR DESCRIPTION
This patch addresses #333 by adding a check to the IPv4 next-hop determination. Running `ring-health` with this patch has the desired result:

```
root@v4less01:/home/v4less# ring-health
ping6: Warning: source address might be selected on device other than: ens18
root@v4less01:/home/v4less# ring-health  -r

  Ubuntu release: 22.04
  Status:         OK
  Last check:     2026-04-14T09:02:13.178210

    OK     The root filesystem is in read/write status
    OK     The root filesystem has enough free disk space
    OK     The boot filesystem has enough free disk space
    OK     The IPv6 address of the node matches the ring database
    OK     The IPv6 gateway is reachable
    OK     There is IPv6 connectivity beyond the gateway
    OK     The IPv4 address of the node matches the ring database
    OK     The IPv4 gateway is reachable
    OK     There is IPv4 connectivity beyond the gateway
    OK     The local host is configured as DNS resolver
    OK     The configured DNS resolvers are functioning
    OK     NTP is running and the clock is synchronized
    OK     The SSH daemon is running
    OK     A webrequest for 'https://github.com/' succeeded
    OK     A webrequest for 'http://nl.archive.ubuntu.com/ubuntu' succeeded
    OK     A webrequest for 'http://apt.ring.nlnog.net/deb/dists/ring/Release' succeeded
    OK     The ansible cron job is correctly configured
    OK     Ansible has recently run
    OK     Pushing this health report to the IPv4 ring API (https://95.211.149.25/) succeeded
    OK     Pushing this health report to the IPv6 ring API (https://[2001:1af8:4013::25]/) succeeded
```