### PR TITLE
Add Enhanced refresh capabilities to OpenBGPd

### DIFF
--- a/roles/openbgpd/templates/bgpd.conf.j2
+++ b/roles/openbgpd/templates/bgpd.conf.j2
@@ -11,6 +11,7 @@ group "peers" {
     multihop 255
     export none
     role customer
+    announce enhanced refresh yes
 
 {% for peer in lg_peers %}
 {% if lg_peers[peer].ipv4|default(None) %}


### PR DESCRIPTION
Enabling the optional Enhanced Refresh capability to OpenBGPd

in OpenBGPd docs:


> announce enhanced refresh (yes|no|enforce)
> 
> If set to yes, the enhanced route refresh capability is announced. If enforce is set, the session will only be established if the neighbor also announces the capability. 
> 
> The default is no.


Even though we see a "Enhanced Refresh" tag on https://lg.ring.nlnog.net/summary without enabling it on OpenBGPd it will never be advertised to the peers

Example from our BIRD session:

```
Local capabilities
  ... Route refresh ... Enhanced refresh ...
Neighbor capabilities
  ... Route refresh ...        # no Enhanced refresh
```

Once this is added we will start seeing the tags in https://lg.ring.nlnog.net/summary go green :)



